### PR TITLE
Fix a typo in manuals/quickstart/index.html

### DIFF
--- a/manuals/quickstart/index.html
+++ b/manuals/quickstart/index.html
@@ -256,7 +256,7 @@ var WRInitTime=(new Date()).getTime();
 
 <h2>Checking for Problems and Your First Sync</h2>
 
-<p>Now that the cobblerd service is up and running, it's time to check for problems. Cobbler's check command will make some suggestions, but it is important to remember that <em>these are mainly only suggestions</em> and probably aren't critical for basic functionality. If you are running iptables or SELinux, it is important to review any messages concering those that check may report.</p>
+<p>Now that the cobblerd service is up and running, it's time to check for problems. Cobbler's check command will make some suggestions, but it is important to remember that <em>these are mainly only suggestions</em> and probably aren't critical for basic functionality. If you are running iptables or SELinux, it is important to review any messages concerning those that check may report.</p>
 
 <div class="highlight"><pre><code class="bash"><span class="nv">$ </span>cobbler check
 The following are potential configuration items that you may want to fix:

--- a/manuals/quickstart/index.html
+++ b/manuals/quickstart/index.html
@@ -225,7 +225,7 @@ var WRInitTime=(new Date()).getTime();
 
 <h2>Files and Directory Notes</h2>
 
-<p>Cobbler makes heavy use of the <code>/var</code> directory. The <code>/var/www/cobbler/ks_mirror</code> directory is where all of the distrubtion and repository files are copied, so you will need 5-10GB of free space per distribution you wish to import.</p>
+<p>Cobbler makes heavy use of the <code>/var</code> directory. The <code>/var/www/cobbler/ks_mirror</code> directory is where all of the distribution and repository files are copied, so you will need 5-10GB of free space per distribution you wish to import.</p>
 
 <p>If you have installed cobbler onto a system that has very little free space in the partition containing <code>/var</code>, please read the <a href="/manuals/2.6.0/2/5_-_Relocating_Your_Installation.html">Relocating Your Installation</a> section of the manual to learn how you can relocate your installation properly.</p>
 


### PR DESCRIPTION
Hi, this is just a typo fix for the quickstart document. :)